### PR TITLE
Bugfix 143: Communication preferences are sometimes shown double

### DIFF
--- a/prisma/migrations/20250214132817_communication_preferences_to_single_object/migration.sql
+++ b/prisma/migrations/20250214132817_communication_preferences_to_single_object/migration.sql
@@ -1,0 +1,42 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[userId]` on the table `CommunicationPreference` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- Find all users which have more than 1 entry in CommunicationPreference
+WITH usersWithMultipleCommunicationPreferences AS (
+    SELECT "userId"
+    FROM "CommunicationPreference"
+    GROUP BY "userId"
+    HAVING COUNT(*) > 1
+),
+    -- This returns rows userId - Method. With a row for each method found
+     unnestedMethods AS (
+         SELECT "userId", unnest("methods") AS method
+         FROM "CommunicationPreference"
+         WHERE "userId" IN (SELECT "userId" FROM usersWithMultipleCommunicationPreferences)
+     )
+UPDATE "CommunicationPreference" cp
+-- Combine all the method rows into one row, where each method appears only once
+SET "methods" = (
+    SELECT array_agg(DISTINCT method)
+    FROM unnestedMethods
+    WHERE "userId" = cp."userId"
+)
+-- Only do this for users with more than one preference
+WHERE "userId" IN (
+    SELECT "userId"
+    FROM usersWithMultipleCommunicationPreferences
+);
+
+-- Now delete all rows, except the first, for each user
+DELETE FROM "CommunicationPreference"
+WHERE ctid NOT IN (
+    SELECT min(ctid)
+    FROM "CommunicationPreference"
+    GROUP BY "userId"
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "CommunicationPreference_userId_key" ON "CommunicationPreference"("userId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,9 +18,9 @@ enum CommunicationMethod {
 }
 
 model BusinessUnit {
-  id         String     @id @default(cuid())
-  unit       String     @unique
-  users      User[]
+  id    String @id @default(cuid())
+  unit  String @unique
+  users User[]
 }
 
 model Survey {
@@ -64,24 +64,24 @@ model QuestionResult {
 
 model CommunicationPreference {
   id      String                @id @default(cuid())
-  userId  String
+  userId  String                @unique
   methods CommunicationMethod[] @default([])
   user    User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
 
 model User {
-  id                       String                    @id @default(cuid())
+  id                       String                   @id @default(cuid())
   name                     String?
-  email                    String?                   @unique
+  email                    String?                  @unique
   emailVerified            DateTime?
   image                    String?
-  roles                    Role[]                    @relation("UserRole")
+  roles                    Role[]                   @relation("UserRole")
   accounts                 Account[]
   questionResults          QuestionResult[]
-  communicationPreferences CommunicationPreference[]
+  communicationPreferences CommunicationPreference?
   sessions                 Session[]
   businessUnitId           String?
-  businessUnit           BusinessUnit?             @relation(fields: [businessUnitId], references: [id])
+  businessUnit             BusinessUnit?            @relation(fields: [businessUnitId], references: [id])
 }
 
 model Account {
@@ -120,7 +120,7 @@ model VerificationToken {
 }
 
 model UsageMetrics {
-  id            String    @id @default(cuid())
-  action        String
-  createdAt     DateTime @default(now())
+  id        String   @id @default(cuid())
+  action    String
+  createdAt DateTime @default(now())
 }

--- a/src/server/api/routers/survey.ts
+++ b/src/server/api/routers/survey.ts
@@ -149,12 +149,9 @@ export const surveyRouter = createTRPCRouter({
       }
 
       // Check if the user already has communication preferences
-      const hasCommunicationPreferences =
-        user.communicationPreferences.length > 0;
-
-      if (hasCommunicationPreferences) {
+      if (user.communicationPreferences) {
         // If the user already has communication preferences, update them
-        const communicationPreferenceId = user.communicationPreferences[0]?.id;
+        const communicationPreferenceId = user.communicationPreferences.id;
 
         await ctx.db.communicationPreference.update({
           where: {


### PR DESCRIPTION
The issue is that users can have multiple `communicationPreferences`. Currently in the model it is defined as `CommunicationPreference[]`. This means that one user can have two rows in that table.

Looking at the database, I can see that Nico Jansen, as in the screenshot above, has multiple entries. For every user, all CommunicationPreference are fetched and then displayed. This results in the duplicate entries. I don't know how these duplicate entries got in the database, I couldn't reproduce it at all.

I believe that the fix is in changing the model from `CommunicationPreference[]` to `CommunicationPreference?`, thereby making the property `userId` unique in the table `CommunicationPreference`. Unfortunately, this requires a complex migration. We have to find all duplicate rows in the table `CommunicationPreference`, merge the methods and then delete all but 1 row.

Fixes #143 