### PR TITLE
Bugfix: Close processes after test ends

### DIFF
--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -1,4 +1,4 @@
-import { spawn } from "child_process";
+import { type ChildProcess, spawn } from "child_process";
 import { expect, type Page } from "@playwright/test";
 import { SurveyPage } from "./survey-page";
 import { type StartedPostgreSqlContainer } from "@testcontainers/postgresql";
@@ -37,8 +37,8 @@ export class TestSetup {
     this.container = container;
   }
 
-  async setupNextProcess(): Promise<number> {
-    return new Promise<number>((res, rej) => {
+  async setupNextProcess(): Promise<{ port: number; process: ChildProcess }> {
+    return new Promise<{ port: number; process: ChildProcess }>((res, rej) => {
       const nextProcess = spawn("npm", ["run", "dev", "--", "--port", "0"], {
         cwd: this.cwd,
         shell: true,
@@ -53,7 +53,10 @@ export class TestSetup {
         process.stdout.write(str);
         const portMatch = /local:\s*http:\/\/.+:(\d+)/gim.exec(str);
         if (portMatch) {
-          res(parseInt(portMatch[1]!));
+            res({
+                port: parseInt(portMatch[1]!),
+                process: nextProcess,
+            });
         }
       });
       nextProcess.stderr.on("data", (chunk: Buffer) => {

--- a/tests/test.spec.ts
+++ b/tests/test.spec.ts
@@ -14,7 +14,17 @@ import {
   TestSetup,
   USER_NAME,
 } from "./test-setup";
+import treeKill from "tree-kill";
 
+const killAllProcesses = async (process: ChildProcess) => {
+    if (process?.pid) {
+        treeKill(process.pid, "SIGKILL", (error) => {
+            if (error) {
+                throw error;
+            }
+        });
+    }
+};
 test.describe("Desktop tests using a single role", () => {
   let nextProcess: ChildProcess;
   let surveyPage: SurveyPage;
@@ -26,7 +36,8 @@ test.describe("Desktop tests using a single role", () => {
     try {
       dbHelper = await DbHelper.create();
       testSetup = new TestSetup(dbHelper.getContainer());
-      const port = await testSetup.setupNextProcess();
+      const { port, process } = await testSetup.setupNextProcess();
+      nextProcess = process;
       surveyPage = await testSetup.setupSurveyPage(page, port);
       await testSetup.setupUserAndSession(page, dbHelper);
 
@@ -52,9 +63,7 @@ test.describe("Desktop tests using a single role", () => {
         await page.context().clearCookies();
       }
 
-      if (nextProcess) {
-        nextProcess.kill();
-      }
+    await killAllProcesses(nextProcess);
     } finally {
       await dbHelper.getContainer().stop();
       await page.close();
@@ -208,7 +217,8 @@ test.describe("Desktop tests using a multiple roles", () => {
     try {
       dbHelper = await DbHelper.create();
       testSetup = new TestSetup(dbHelper.getContainer());
-      const port = await testSetup.setupNextProcess();
+      const { port, process } = await testSetup.setupNextProcess();
+      nextProcess = process;
       surveyPage = await testSetup.setupSurveyPage(page, port);
       await testSetup.setupUserAndSession(page, dbHelper);
 
@@ -230,9 +240,7 @@ test.describe("Desktop tests using a multiple roles", () => {
       await page.context().clearCookies();
     }
     await page.close();
-    if (nextProcess) {
-      nextProcess.kill();
-    }
+    await killAllProcesses(nextProcess);
     await dbHelper.getContainer().stop();
   });
 
@@ -307,7 +315,8 @@ test.describe("Mobile tests using a single role", () => {
     try {
       dbHelper = await DbHelper.create();
       testSetup = new TestSetup(dbHelper.getContainer());
-      const port = await testSetup.setupNextProcess();
+      const { port, process } = await testSetup.setupNextProcess();
+      nextProcess = process;
       surveyPage = await testSetup.setupSurveyPage(page, port);
       await testSetup.setupUserAndSession(page, dbHelper);
 
@@ -333,9 +342,7 @@ test.describe("Mobile tests using a single role", () => {
         await page.context().clearCookies();
       }
 
-      if (nextProcess) {
-        nextProcess.kill();
-      }
+      await killAllProcesses(nextProcess);
     } finally {
       await dbHelper.getContainer().stop();
       await page.close();
@@ -473,7 +480,8 @@ test.describe("Mobile tests using multiple roles", () => {
     try {
       dbHelper = await DbHelper.create();
       testSetup = new TestSetup(dbHelper.getContainer());
-      const port = await testSetup.setupNextProcess();
+      const { port, process } = await testSetup.setupNextProcess();
+      nextProcess = process;
       surveyPage = await testSetup.setupSurveyPage(page, port);
       await testSetup.setupUserAndSession(page, dbHelper);
 
@@ -499,9 +507,7 @@ test.describe("Mobile tests using multiple roles", () => {
         await page.context().clearCookies();
       }
 
-      if (nextProcess) {
-        nextProcess.kill();
-      }
+      await killAllProcesses(nextProcess);
     } finally {
       await dbHelper.getContainer().stop();
       await page.close();


### PR DESCRIPTION
Added a function `killAllProcesses` in `test.spec.ts` to kill all processes at the end of a test. Also it seems Prettier hadn't been applied to the test files yet.

Closes #166 