### PR TITLE
`fix(layout)` | Fix uneven layout on the `Find the Expert` page

### DIFF
--- a/src/components/ui/show-tech-search-wrapper.tsx
+++ b/src/components/ui/show-tech-search-wrapper.tsx
@@ -137,7 +137,7 @@ const ShowTechSearchWrapper = ({
                                 name="tech"
                                 render={({ field }) => (
                                     <FormItem>
-                                        <Label className="text-nowrap" >
+                                        <Label className="text-nowrap">
                                             Viewing results for technology:
                                         </Label>
                                         <FormControl>

--- a/src/components/ui/show-tech-search-wrapper.tsx
+++ b/src/components/ui/show-tech-search-wrapper.tsx
@@ -137,7 +137,7 @@ const ShowTechSearchWrapper = ({
                                 name="tech"
                                 render={({ field }) => (
                                     <FormItem>
-                                        <Label>
+                                        <Label className="text-nowrap" >
                                             Viewing results for technology:
                                         </Label>
                                         <FormControl>


### PR DESCRIPTION
This PR fixes #183 

![LayoutWithFix](https://github.com/user-attachments/assets/833345b0-e7f9-4116-990e-c5bef87b577f)
